### PR TITLE
Added endFor to the syntax highlighting

### DIFF
--- a/grammars/igor.cson
+++ b/grammars/igor.cson
@@ -72,6 +72,10 @@
       'name': 'keyword.control.igor'
     }
     {
+      'match': '(?i)\\b(endfor)\\b'
+      'name': 'keyword.control.igor'
+    }
+    {
       'match': '(?i)\\b(endif)\\b'
       'name': 'keyword.control.igor'
     }


### PR DESCRIPTION
Really simple edit adding "endFor" to syntax highlighting
